### PR TITLE
Add spacewalk assets to talisman

### DIFF
--- a/data/chaindata.json
+++ b/data/chaindata.json
@@ -396,6 +396,55 @@
             "ed": "0",
             "onChainId": "{\"XCM\":1}",
             "coingeckoId": "tether"
+          },
+          {
+            "symbol": "XLM",
+            "decimals": 12,
+            "ed": "1000",
+            "onChainId": "{\"Stellar\": \"StellarNative\" }",
+            "coingeckoId": "stellar"
+          },
+          {
+            "symbol": "TZS.s",
+            "decimals": 12,
+            "ed": "1000",
+            "onChainId": "{\"Stellar\": { \"AlphaNum4\": { \"code\": \"0x545a5300\", \"issuer\": \"0x34c94b2a4ba9e8b57b22547dcbb30f443c4cb02da3829a89aa1bd4780e4466ba\" } } }",
+            "coingeckoId": ""
+          },
+          {
+            "symbol": "BRL.s",
+            "decimals": 12,
+            "ed": "1000",
+            "onChainId": "{\"Stellar\": { \"AlphaNum4\": { \"code\": \"0x42524c00\", \"issuer\": \"0xeaac68d4d0e37b4c24c2536916e830735f032d0d6b2a1c8fca3bc5a25e083e3a\" } } }",
+            "coingeckoId": ""
+          },
+          {
+            "symbol": "USDC.s",
+            "decimals": 12,
+            "ed": "1000",
+            "onChainId": "{\"Stellar\": { \"AlphaNum4\": { \"code\": \"USDC\", \"issuer\": \"0x3b9911380efe988ba0a8900eb1cfe44f366f7dbe946bed077240f7f624df15c5\" } } }",
+            "coingeckoId": "usdc"
+          },
+          {
+            "symbol": "AUDD.s",
+            "decimals": 12,
+            "ed": "1000",
+            "onChainId": "{\"Stellar\": { \"AlphaNum4\": { \"code\": \"AUDD\", \"issuer\": \"0xc5fbe9979e240552860221f4fe2f2219f35e40458b8b58fc32da520a154a561d\" } } }",
+            "coingeckoId": ""
+          },
+          {
+            "symbol": "EURC.s",
+            "decimals": 12,
+            "ed": "1000",
+            "onChainId": "{\"Stellar\": { \"AlphaNum4\": { \"code\": \"EURC\", \"issuer\": \"0x2112ee863867e4e219fe254c0918b00bc9ea400775bfc3ab4430971ce505877c\" } } }",
+            "coingeckoId": ""
+          },
+          {
+            "symbol": "NGNC.s",
+            "decimals": 12,
+            "ed": "1000",
+            "onChainId": "{\"Stellar\": { \"AlphaNum4\": { \"code\": \"NGNC\", \"issuer\": \"0x241afadf31883f79972545fc64f3b5b0c95704c6fb4917474e42b0057841606b\" } } }",
+            "coingeckoId": ""
           }
         ]
       }
@@ -3121,6 +3170,62 @@
             "ed": "0",
             "onChainId": "{\"XCM\":1}",
             "coingeckoId": "tether"
+          },
+          {
+            "symbol": "XLM",
+            "decimals": 12,
+            "ed": "1000",
+            "onChainId": "{\"Stellar\": \"StellarNative\" }",
+            "coingeckoId": "stellar"
+          },
+          {
+            "symbol": "TZS.s",
+            "decimals": 12,
+            "ed": "1000",
+            "onChainId": "{\"Stellar\": { \"AlphaNum4\": { \"code\": \"0x545a5300\", \"issuer\": \"0x34c94b2a4ba9e8b57b22547dcbb30f443c4cb02da3829a89aa1bd4780e4466ba\" } } }",
+            "coingeckoId": ""
+          },
+          {
+            "symbol": "BRL.s",
+            "decimals": 12,
+            "ed": "1000",
+            "onChainId": "{\"Stellar\": { \"AlphaNum4\": { \"code\": \"0x42524c00\", \"issuer\": \"0xeaac68d4d0e37b4c24c2536916e830735f032d0d6b2a1c8fca3bc5a25e083e3a\" } } }",
+            "coingeckoId": ""
+          },
+          {
+            "symbol": "USDC.s",
+            "decimals": 12,
+            "ed": "1000",
+            "onChainId": "{\"Stellar\": { \"AlphaNum4\": { \"code\": \"USDC\", \"issuer\": \"0x3b9911380efe988ba0a8900eb1cfe44f366f7dbe946bed077240f7f624df15c5\" } } }",
+            "coingeckoId": "usdc"
+          },
+          {
+            "symbol": "AUDD.s",
+            "decimals": 12,
+            "ed": "1000",
+            "onChainId": "{\"Stellar\": { \"AlphaNum4\": { \"code\": \"AUDD\", \"issuer\": \"0xc5fbe9979e240552860221f4fe2f2219f35e40458b8b58fc32da520a154a561d\" } } }",
+            "coingeckoId": ""
+          },
+          {
+            "symbol": "EURC.s",
+            "decimals": 12,
+            "ed": "1000",
+            "onChainId": "{\"Stellar\": { \"AlphaNum4\": { \"code\": \"EURC\", \"issuer\": \"0x2112ee863867e4e219fe254c0918b00bc9ea400775bfc3ab4430971ce505877c\" } } }",
+            "coingeckoId": ""
+          },
+          {
+            "symbol": "NGNC.s",
+            "decimals": 12,
+            "ed": "1000",
+            "onChainId": "{\"Stellar\": { \"AlphaNum4\": { \"code\": \"NGNC\", \"issuer\": \"0x241afadf31883f79972545fc64f3b5b0c95704c6fb4917474e42b0057841606b\" } } }",
+            "coingeckoId": ""
+          },
+          {
+            "symbol": "GLMR",
+            "decimals": 18,
+            "ed": "1",
+            "onChainId": "{\"XCM\":6}",
+            "coingeckoId": "moonbeam"
           }
         ]
       }
@@ -3678,7 +3783,11 @@
     "subscanUrl": "https://shiden.subscan.io/",
     "chainspecQrUrl": "https://metadata.novasama.io/qr/shiden_specs.png",
     "latestMetadataQrUrl": "https://metadata.novasama.io/qr/shiden_metadata_latest.apng",
-    "rpcs": ["wss://shiden-rpc.dwellir.com"],
+    "rpcs": [
+      "wss://shiden-rpc.dwellir.com",
+      "wss://shiden.public.curie.radiumblock.co/ws",
+      "wss://rpc.shiden.astar.network"
+    ],
     "paraId": 2007,
     "relay": {
       "id": "kusama"

--- a/data/chaindata.json
+++ b/data/chaindata.json
@@ -3783,6 +3783,7 @@
     "subscanUrl": "https://shiden.subscan.io/",
     "chainspecQrUrl": "https://metadata.novasama.io/qr/shiden_specs.png",
     "latestMetadataQrUrl": "https://metadata.novasama.io/qr/shiden_metadata_latest.apng",
+    "rpcs": ["wss://shiden-rpc.dwellir.com"],
     "paraId": 2007,
     "relay": {
       "id": "kusama"

--- a/data/chaindata.json
+++ b/data/chaindata.json
@@ -3783,11 +3783,6 @@
     "subscanUrl": "https://shiden.subscan.io/",
     "chainspecQrUrl": "https://metadata.novasama.io/qr/shiden_specs.png",
     "latestMetadataQrUrl": "https://metadata.novasama.io/qr/shiden_metadata_latest.apng",
-    "rpcs": [
-      "wss://shiden-rpc.dwellir.com",
-      "wss://shiden.public.curie.radiumblock.co/ws",
-      "wss://rpc.shiden.astar.network"
-    ],
     "paraId": 2007,
     "relay": {
       "id": "kusama"


### PR DESCRIPTION
closes https://github.com/pendulum-chain/tasks/issues/248

add USDC.s, XLM.s, TZS.s, BRL.s, AUDD.s, EURC.s, NGNC.s, GLMR to Pendulum
Info based on [pendulum_transfer20.js transaction](https://github.com/pendulum-chain/transaction-builder/blob/9c8be6de9b9e0b92ad6150e8b8ee63095894800a/transactions/pendulum_transfer20.js#L39)

add USDC.s, XLM.s, TZS.s, BRL.s, AUDD.s, EURC.s, NGNC.s to Amplitude
Info based on [amplitude_transfer21.js](https://github.com/pendulum-chain/transaction-builder/blob/9c8be6de9b9e0b92ad6150e8b8ee63095894800a/transactions/amplitude_transfer21.js#L22)