### PR TITLE
[DO NOT MERGE] 378 create a pr to add pendulum assets

### DIFF
--- a/data/chaindata.json
+++ b/data/chaindata.json
@@ -3389,16 +3389,23 @@
           {
             "symbol": "DOT",
             "decimals": 10,
-            "ed": "0",
+            "ed": "1000",
             "onChainId": "{\"type\":\"XCM\",\"value\":0}",
             "coingeckoId": "polkadot"
           },
           {
             "symbol": "USDT",
             "decimals": 6,
-            "ed": "0",
+            "ed": "1000",
             "onChainId": "{\"type\":\"XCM\",\"value\":1}",
             "coingeckoId": "tether"
+          },
+          {
+            "symbol": "USDC",
+            "decimals": 6,
+            "ed": "1000",
+            "onChainId": "{\"type\":\"XCM\",\"value\":2}",
+            "coingeckoId": "usdc"
           },
           {
             "symbol": "GLMR",
@@ -3442,13 +3449,69 @@
             "symbol": "EURC.s",
             "decimals": 12,
             "ed": "1000",
-            "onChainId": "{\"type\":\"Stellar\",\"value\":{\"type\":\"AlphaNum4\",\"value\":{\"code\":\"bin:EURC\",\"issuer\":\"hex:0x2112ee863867e4e219fe254c0918b00bc9ea400775bfc3ab4430971ce505877c\"}}}"
+            "onChainId": "{\"type\":\"Stellar\",\"value\":{\"type\":\"AlphaNum4\",\"value\":{\"code\":\"bin:EURC\",\"issuer\":\"hex:0x2112ee863867e4e219fe254c0918b00bc9ea400775bfc3ab4430971ce505877c\"}}}",
+            "coingeckoId": "eurc"
+          },
+          {
+            "symbol": "EURC.s",
+            "decimals": 12,
+            "ed": "1000",
+            "onChainId": "{\"type\":\"Stellar\",\"value\":{\"type\":\"AlphaNum4\",\"value\":{\"code\":\"bin:EURC\",\"issuer\":\"hex:0xcf4f5a26e2090bb3adcf02c7a9d73dbfe6659cc690461475b86437fa49c71136\"}}}",
+            "coingeckoId": "eurc"
           },
           {
             "symbol": "NGNC.s",
             "decimals": 12,
             "ed": "1000",
             "onChainId": "{\"type\":\"Stellar\",\"value\":{\"type\":\"AlphaNum4\",\"value\":{\"code\":\"bin:NGNC\",\"issuer\":\"hex:0x241afadf31883f79972545fc64f3b5b0c95704c6fb4917474e42b0057841606b\"}}}"
+          },
+          {
+            "symbol": "BRZ",
+            "decimals": 18,
+            "ed": "1000",
+            "onChainId": "{\"type\":\"XCM\",\"value\":4}",
+            "coingeckoId": "brazilian-digital-token"
+          },
+          {
+            "symbol": "PINK",
+            "decimals": 10,
+            "ed": "1000",
+            "onChainId": "{\"type\":\"XCM\",\"value\":7}"
+          },
+          {
+            "symbol": "HDX",
+            "decimals": 12,
+            "ed": "1000",
+            "onChainId": "{\"type\":\"XCM\",\"value\":8}",
+            "coingeckoId": "hydration"
+          },
+          {
+            "symbol": "ASTR",
+            "decimals": 18,
+            "ed": "0",
+            "onChainId": "{\"type\":\"XCM\",\"value\":9}",
+            "coingeckoId": "astar"
+          },
+          {
+            "symbol": "vDOT",
+            "decimals": 10,
+            "ed": "1000000",
+            "onChainId": "{\"type\":\"XCM\",\"value\":10}",
+            "coingeckoId": "voucher-dot"
+          },
+          {
+            "symbol": "BNC",
+            "decimals": 12,
+            "ed": "10000000000",
+            "onChainId": "{\"type\":\"XCM\",\"value\":11}",
+            "coingeckoId": "bifrost-native-coin"
+          },
+          {
+            "symbol": "USDC.axl",
+            "decimals": 6,
+            "ed": "1000",
+            "onChainId": "{\"type\":\"XCM\",\"value\":12}",
+            "coingeckoId": "axelar-bridged-usdc"
           }
         ]
       }

--- a/data/chaindata.json
+++ b/data/chaindata.json
@@ -3410,7 +3410,7 @@
           {
             "symbol": "GLMR",
             "decimals": 18,
-            "ed": "1",
+            "ed": "1000",
             "onChainId": "{\"type\":\"XCM\",\"value\":6}",
             "coingeckoId": "moonbeam"
           },
@@ -3489,7 +3489,7 @@
           {
             "symbol": "ASTR",
             "decimals": 18,
-            "ed": "0",
+            "ed": "1000",
             "onChainId": "{\"type\":\"XCM\",\"value\":9}",
             "coingeckoId": "astar"
           },

--- a/data/chaindata.json
+++ b/data/chaindata.json
@@ -3437,7 +3437,8 @@
             "symbol": "USDC.s",
             "decimals": 12,
             "ed": "1000",
-            "onChainId": "{\"type\":\"Stellar\",\"value\":{\"type\":\"AlphaNum4\",\"value\":{\"code\":\"bin:USDC\",\"issuer\":\"hex:0x3b9911380efe988ba0a8900eb1cfe44f366f7dbe946bed077240f7f624df15c5\"}}}"
+            "onChainId": "{\"type\":\"Stellar\",\"value\":{\"type\":\"AlphaNum4\",\"value\":{\"code\":\"bin:USDC\",\"issuer\":\"hex:0x3b9911380efe988ba0a8900eb1cfe44f366f7dbe946bed077240f7f624df15c5\"}}}",
+            "coingeckoId": "usdc"
           },
           {
             "symbol": "AUDD.s",


### PR DESCRIPTION
As before the objective of this PR is not to merge but to check it. Later we can merge to upstream Talisman/chaindata repository.

Related: [Tasks/#378](https://github.com/pendulum-chain/tasks/issues/378).

Some of the required tokens on the issue where already included on the Pendulum configuration. This adds:
- USDC
- BRZ
- PINK
- HDX
- ASTR (ED taken from our definitions in `orml_tokens` pallet [definition](https://github.com/pendulum-chain/pendulum/blob/main/runtime/pendulum/src/lib.rs#L825C9-L825C17))
- vDOT
- BNC
- USDC.axl

Also, adds ED for existing DOT and USDT.

